### PR TITLE
Add note about MC being used to change area

### DIFF
--- a/Attorney Online Client-Server Network Specification.md
+++ b/Attorney Online Client-Server Network Specification.md
@@ -157,7 +157,7 @@ Some servers support a looping feature where a song is played continuously, with
 
 C: **MC#<areaname: string>#<char_id: int>#%**
 
-The MC packet is reused for this purpose. Once received, the server will send 2 HP's, BN, and LE packets, to load the area info. After that, it will start sending messages from the new area. If the area does not exist, the packet is ignored.
+The MC packet is reused for this purpose. Once received the server will send 2 HP's, 1 BN, and 1 LE packets, to load the area info. After that it will start sending messages from the new area. If the area does not exist the packet is ignored.
 
 # Judge commands
 

--- a/Attorney Online Client-Server Network Specification.md
+++ b/Attorney Online Client-Server Network Specification.md
@@ -157,7 +157,7 @@ Some servers support a looping feature where a song is played continuously, with
 
 C: **MC#<areaname: string>#<char_id: int>#%**
 
-The MC packet is reused for this purpose. Once received, the server will start sending messages from the corrisponding area name. If the area (or music) does not exist, the packet is ignored.
+The MC packet is reused for this purpose. Once received, the server will send 2 HP's, BN, and LE packets, to load the area info. After that, it will start sending messages from the new area. If the area does not exist, the packet is ignored.
 
 # Judge commands
 

--- a/Attorney Online Client-Server Network Specification.md
+++ b/Attorney Online Client-Server Network Specification.md
@@ -153,6 +153,12 @@ S: (same)
 
 Some servers support a looping feature where a song is played continuously, without receiving client music requests.
 
+# Area Switching
+
+C: **MC#<areaname: string>#<char_id: int>#%**
+
+The MC packet is reused for this purpose. Once received, the server will start sending messages from the corrisponding area name. If the area (or music) does not exist, the packet is ignored.
+
 # Judge commands
 
 In-game, characters in the "jud" position have some special abilities.  


### PR DESCRIPTION
I was working with this documentation, and I spent too much time trying to figure out why a spectator was able to change areas while being unable to send OOC messages. I found my answer after using wireshark but info like this should be in these docs.